### PR TITLE
[csharp] Use the provided 'sourceFolder' property to generate the test folder 

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -281,6 +281,9 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
         // {{sourceFolder}}
         if (additionalProperties.containsKey(CodegenConstants.SOURCE_FOLDER)) {
             setSourceFolder((String) additionalProperties.get(CodegenConstants.SOURCE_FOLDER));
+            
+            // TODO: Move to its own option when a parameter for 'testFolder' is added.
+            setTestFolder((String) additionalProperties.get(CodegenConstants.SOURCE_FOLDER));
         } else {
             additionalProperties.put(CodegenConstants.SOURCE_FOLDER, this.sourceFolder);
         }
@@ -1150,6 +1153,10 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
 
     public void setSourceFolder(String sourceFolder) {
         this.sourceFolder = sourceFolder;
+    }
+    
+    public void setTestFolder(String testFolder) {
+        this.testFolder = testFolder;
     }
 
     public String getInterfacePrefix() {


### PR DESCRIPTION
Hi all!

This issue is regarding the `csharp-netcore` generator. There is a bit of an inconsistency in how the test folders are generated when the `sourceFolder` property is provided. For example: 
- Set the option `sourceFolder` to anything other than `src`. 
   - In this case, I left it empty:  `--additional-properties=sourceFolder=""`
- Generate the client
- See that the client was generated in the provided `sourceFolder`... but the tests where generated in `src`:
![image](https://user-images.githubusercontent.com/16015792/139574449-2632fd22-5be2-42bf-b272-e5151e682def.png)

In the `AbstractCSharpCodegen.java`, there is a TODO a few years old saying that a separate option for `testFolder` could be added: 
https://github.com/OpenAPITools/openapi-generator/blob/8551b0af492286a431c95ce3a37d7edf1ef4870a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java#L73-L75

Until that is implemented, I created a little workaround, assigning the provided `sourceFolder` parameter to the `testFolder`. 

With this change, the projects are generated as expected:
![image](https://user-images.githubusercontent.com/16015792/139577691-7df23aa3-3804-4d2d-a1f1-b48ab209e204.png)

Related issue: #1390

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
